### PR TITLE
Fix model name detection

### DIFF
--- a/pack.py
+++ b/pack.py
@@ -10,4 +10,3 @@ def main(dst, src, name):
         rename(path.join(dst, name + '.zip'), name + ".fmu")
     except FileExistsError:
         exit("Archive %s already exists." % (name))
-        

--- a/unpack.py
+++ b/unpack.py
@@ -117,10 +117,11 @@ def handle_zip(dst, zip_path):
             # Next, we split it with '_' in order to get rid of _grt_rtw
             # And we join together all elements except the last two so we support model names with underscores.
             # '_'.join(<code-in-here>.split('_')[:-2])
-            environ['SIMX_MODEL_NAME'] = '_'.join(listdir(path.join(dst, line))[0].split('_')[:-2])
             for folder_path in listdir(path.join(dst, line)):
-                if path.isdir(path.join(dst, line + "/" + folder_path)):
-                    TEMPLATE_REPLACE['modelName'] = '_'.join(listdir(path.join(dst, line))[0].split('_')[:-2])
+                if path.isdir(path.join(dst, line, folder_path)):
+                    modelName = '_'.join(folder_path.split('_')[:-2])
+                    environ['SIMX_MODEL_NAME'] = modelName
+                    TEMPLATE_REPLACE['modelName'] = modelName
                     break
             if TEMPLATE_REPLACE['folderName'] == TEMPLATE_REPLACE['modelName']:
                 rename(path.join(dst, TEMPLATE_REPLACE['folderName']), path.join(dst, "old_" + TEMPLATE_REPLACE['folderName']))


### PR DESCRIPTION
Model name detection failed if there is an additional file in the build folder, e.g., if it looks like

```
Test.zip
 - build_dir
   - Test_grt_rtw
   - Test.exe
 - R2018a
```